### PR TITLE
Reworked logic and tail feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 A hacky [password store](https://www.passwordstore.org/) extension for the [ulauncher](https://ulauncher.io/).
 
-This extension needs:
-- find
-- pass (duh!)
-- sed
-
-It gets the data from .password-store directory under your home folder.
-
 ![extension screenshot](https://i.imgur.com/T9mYiIk.png)
+
+Latest features include:
+- Search & copy passwords to clipboard.
+- Setting a custom password-store path.
+- Running a custom command before and after copying password. (Useful for putting clipboard managers into offline mode)
+- Optional [pass-extension-tail](https://git.io/vpSgV) support.

--- a/main.py
+++ b/main.py
@@ -28,11 +28,13 @@ class KeywordQueryEventListener(EventListener):
 
     def on_event(self, event, extension):
         items = []
-        pass_list = self.list_gpg(path.join(path.expanduser("~"), ".password-store"))
         myList = event.query.split(" ")
+        password_store_path = extension.preferences['password_store_path']
+        password_store_path = path.expanduser(password_store_path) if "~" in password_store_path else password_store_path
         custom_command = extension.preferences['custom_command']
         custom_command_delay = extension.preferences['custom_command_delay']
         enable_tail = extension.preferences['enable_tail']
+        pass_list = self.list_gpg(password_store_path)
 
         if not myList[1]:
             for line in pass_list:

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
         "id": "custom_command_delay",
         "type": "input",
         "name": "Delay time before executing second command (by seconds)",
-        "description": "Sometimes, executing two commands one ofter the other causes problems. Increase delay time to solve this",
+        "description": "Sometimes, executing two commands one ofter the other causes problems. Increase delay time to solve this.",
         "default_value": 0
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,12 @@
         "default_value": "pass"
     },
     {
+        "id": "password_store_path",
+        "type": "input",
+        "name": "Path to password-store folder",
+        "default_value": "~/.password-store"
+    },
+    {
         "id": "custom_command",
         "type": "input",
         "name": "Run custom command",

--- a/manifest.json
+++ b/manifest.json
@@ -13,20 +13,31 @@
       "id": "pass_ext",
       "type": "keyword",
       "name": "Pass",
-      "description": "Copy your passwords from password store",
+      "description": "Shortcut for enabling the extension.",
       "default_value": "pass"
     },
     {
         "id": "custom_command",
         "type": "input",
         "name": "Run custom command",
-        "description": "Run custom command before and after copying password. Ex: Put clipboard manager into offline (unmonitoring) mode"
+        "description": "Run custom command before and after copying password. Ex: Put clipboard manager into offline (unmonitoring) mode. (Tip: Use full binary path)"
     },
     {
         "id": "custom_command_delay",
         "type": "input",
-        "name": "Delay time before executing second command",
+        "name": "Delay time before executing second command (by seconds)",
         "description": "Sometimes, executing two commands one ofter the other causes problems. Increase delay time to solve this",
+        "default_value": 0
+    },
+    {
+        "id": "enable_tail",
+        "type": "select",
+        "name": "Enable tail command",
+        "description": "Trigger the tail command by adding \"tail\" to any query. <br><strong>Note:</strong> Requires pass-extension-tail extension. (https://git.io/vpSgV)",
+        "options": [
+            {"value": 1, "text": "Enable"},
+            {"value": 0, "text": "Disable"}
+        ],
         "default_value": 0
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -10,11 +10,11 @@
   },
   "preferences": [
     {
-      "id": "pass_ext",
-      "type": "keyword",
-      "name": "Pass",
-      "description": "Shortcut for enabling the extension.",
-      "default_value": "pass"
+        "id": "pass_ext",
+        "type": "keyword",
+        "name": "Pass",
+        "description": "Shortcut for enabling the extension.",
+        "default_value": "pass"
     },
     {
         "id": "custom_command",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "1",
+  "manifest_version": "2",
   "api_version": "1",
   "name": "Password store",
   "description": "Copy your passwords from password store",


### PR DESCRIPTION
Sorry for the frequent requests. This time I tried to group as many commits as I could.

1. `os.popen` is apparently [deprecated](https://docs.python.org/2/library/os.html#os.popen) and considered bad practice in general (mostly for security reasons).
I reworked the same functionality using Python commands, and even though not so elegant of a solution as I'd have liked it to be, running timing test showed very good results.
Here's the function I used for timing:
```python
def timing(f):
    def wrap(*args):
        time1 = time.time()
        ret = f(*args)
        time2 = time.time()
        print '%s function took %0.3f ms' % (f.func_name, (time2-time1)*1000.0)
        return ret
    return wrap
```
And the tested functions:
```python
@timing
def list_gpg(top):
    t = []
    for root, dirs, files in walk(top):
        for f in files:
            name, ext = path.splitext(f)
            if ext == ".gpg":
                t += [name if root == top else "{}/{}".format(path.relpath(root, top), name)]
    return sorted(t)

@timing
def list_gpg_find():
    pipe = popen("find ~/.password-store/ | sed '/gpg$/!d;s/.*.password-store\///;s/.gpg$//'")
    output = pipe.read()
    return output.splitlines()
```
I tried writing "amazon" and here's the result:
```
ulauncher-password-store | 2018-05-12 16:51:43,787 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event PreferencesEvent
ulauncher-password-store | 2018-05-12 16:51:46,091 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
list_gpg function took 0.450 ms
list_gpg_find function took 14.470 ms
ulauncher-password-store | 2018-05-12 16:51:46,107 | DEBUG | ulauncher.api.client.Client: send() | Send message
ulauncher-password-store | 2018-05-12 16:51:55,047 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
list_gpg function took 1.227 ms
list_gpg_find function took 18.935 ms
ulauncher-password-store | 2018-05-12 16:51:55,069 | DEBUG | ulauncher.api.client.Client: send() | Send message
ulauncher-password-store | 2018-05-12 16:51:55,296 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
list_gpg function took 1.483 ms
list_gpg_find function took 21.258 ms
ulauncher-password-store | 2018-05-12 16:51:55,320 | DEBUG | ulauncher.api.client.Client: send() | Send message
ulauncher-password-store | 2018-05-12 16:51:55,646 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
list_gpg function took 2.076 ms
list_gpg_find function took 18.653 ms
ulauncher-password-store | 2018-05-12 16:51:55,668 | DEBUG | ulauncher.api.client.Client: send() | Send message
ulauncher-password-store | 2018-05-12 16:51:56,416 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
list_gpg function took 1.292 ms
list_gpg_find function took 15.851 ms
ulauncher-password-store | 2018-05-12 16:51:56,434 | DEBUG | ulauncher.api.client.Client: send() | Send message
ulauncher-password-store | 2018-05-12 16:51:56,542 | DEBUG | ulauncher.api.client.Client: on_message() | Incoming event KeywordQueryEvent
list_gpg function took 1.470 ms
list_gpg_find function took 21.830 ms
```
I actually wanted to use the internal `list` command at first, using [subprocess.check_output](https://docs.python.org/2/library/subprocess.html#subprocess.check_output) but the output format is just so annoying to work with that I gave up on this idea.
However, one advantage this method could have is listing passwords that aren't stored at `~/password-store` and are known to `pass`. 
Maybe we should consider adding an option for selecting different directory path? I'm not entirely sure...

2. This one is a bit of a stretch but I wanted to also be able to use the `tail` extension command to show other helpful information (such as login info, etc.) 
I wasn't sure how to implement this at first, but since it's probably going to be rarely used I disabled it by default and allowed it to be triggered via the last query `tail`.
Also, with a long list it can, again, become very nasty (and slow) so I limited it to one result only, since it's probably only going to be used on pin-point searches.
Finally, there's an annoying limitation where an OS password prompt will pop up before we can access the tail information (if outside the timeout zone) and I couldn't find a proper way to re-run the search. Unless you have something in mind, the user will have to recreate his query somehow (delete and retype the "l" in "tail", or something) for the tail information to display.